### PR TITLE
api field as password field

### DIFF
--- a/src/app/auth/pages/login/login.component.html
+++ b/src/app/auth/pages/login/login.component.html
@@ -8,7 +8,7 @@
         <form [formGroup]="form" (submit)="doLogin()">
           <div class="form-group">
             <label for="inputApiKey">{{ "API Key" }}</label>
-            <input type="text" id="inputApiKey" formControlName="apiKey" class="form-control" required autocomplete="off"/>
+            <input type="password" id="inputApiKey" formControlName="apiKey" class="form-control" required autocomplete="off"/>
           </div>
 
           <small>

--- a/src/app/instances/pages/reset-instance-token/reset-instance-token.component.html
+++ b/src/app/instances/pages/reset-instance-token/reset-instance-token.component.html
@@ -18,7 +18,7 @@
       <form [formGroup]="form" (submit)="validateAndReset()">
         <div class="form-group">
           <label for="inputApiKey">Current api key</label>
-          <input id="inputApiKey" class="form-control" formControlName="currentApiKey"/>
+          <input type="password" id="inputApiKey" class="form-control" formControlName="currentApiKey"/>
         </div>
         <div class="form-group">
           <label for="inputAdminUsername">Admin username</label>


### PR DESCRIPTION
I think it is better to take the API fields as the keyword field.

1. the API can not be seen when you enter it
2. password databases recognize the field automatically